### PR TITLE
ci: add ci/cd workflows and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,12 @@ jobs:
           git add pubspec.yaml CHANGELOG.md
           git commit -m "chore(release): v${{ steps.bump.outputs.version }}"
 
+      - name: Rebase onto latest main
+        if: steps.bump.outputs.skip != 'true'
+        run: |
+          git fetch origin main
+          git rebase origin/main
+
       - name: Create tag
         if: steps.bump.outputs.skip != 'true'
         run: |


### PR DESCRIPTION
## Summary
- rebase the release commit onto the latest main branch before tagging and pushing

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cabc0c73288332a492a38770d1689c