### PR TITLE
Dev

### DIFF
--- a/lib/src/splash_builder.dart
+++ b/lib/src/splash_builder.dart
@@ -132,7 +132,9 @@ class _SplashBuilderState extends ConsumerState<SplashBuilder> {
     return config.splashBuilder(
       _getFirstError(ref, config, oneTimeSplashTask),
 
-      _hasAnyError(ref, config, oneTimeSplashTask) ? _createRetryCallback(oneTimeSplashTask) : null,
+      _hasAnyError(ref, config, oneTimeSplashTask)
+          ? _createRetryCallback(oneTimeSplashTask)
+          : null,
     );
   }
 
@@ -165,19 +167,28 @@ class _SplashBuilderState extends ConsumerState<SplashBuilder> {
     AsyncValue<bool> oneTimeTask,
   ) {
     if (oneTimeTask.hasError) {
-      return SplashTaskError(error: oneTimeTask.error!, stack: oneTimeTask.stackTrace!);
+      return SplashTaskError(
+        error: oneTimeTask.error!,
+        stack: oneTimeTask.stackTrace!,
+      );
     }
 
     final tasks = config.reactiveTasks;
     for (int i = 0; i < tasks.length; i++) {
       final watchState = ref.read(_reactiveSplashTasksProvider(i));
       if (watchState.hasError) {
-        return SplashTaskError(error: watchState.error!, stack: watchState.stackTrace!);
+        return SplashTaskError(
+          error: watchState.error!,
+          stack: watchState.stackTrace!,
+        );
       }
 
       final executeState = ref.read(_reactiveSplashTasksExecuteProvider(i));
       if (executeState.hasError) {
-        return SplashTaskError(error: executeState.error!, stack: executeState.stackTrace!);
+        return SplashTaskError(
+          error: executeState.error!,
+          stack: executeState.stackTrace!,
+        );
       }
     }
 

--- a/lib/src/splash_task.dart
+++ b/lib/src/splash_task.dart
@@ -1,6 +1,8 @@
 part of 'src.dart';
 
-final _splashConfigProvider = Provider<SplashConfig?>((ref) => throw UnimplementedError());
+final _splashConfigProvider = Provider<SplashConfig?>(
+  (ref) => throw UnimplementedError(),
+);
 
 final _oneTimeSplashTasksProvider = FutureProvider<bool>((ref) async {
   final config = ref.watch(_splashConfigProvider);
@@ -28,35 +30,38 @@ final _oneTimeSplashTasksProvider = FutureProvider<bool>((ref) async {
   return true;
 });
 
-final _reactiveSplashTasksProvider = FutureProvider.autoDispose.family<dynamic, int>((
-  ref,
-  index,
-) async {
-  final config = ref.watch(_splashConfigProvider);
-  final tasks = config?.reactiveTasks;
-  if (config == null || tasks == null || index >= tasks.length) return;
+final _reactiveSplashTasksProvider = FutureProvider.autoDispose
+    .family<dynamic, int>((
+      ref,
+      index,
+    ) async {
+      final config = ref.watch(_splashConfigProvider);
+      final tasks = config?.reactiveTasks;
+      if (config == null || tasks == null || index >= tasks.length) return;
 
-  final task = tasks[index];
-  return await task.watch(ref);
-});
+      final task = tasks[index];
+      return await task.watch(ref);
+    });
 
-final _reactiveSplashTasksExecuteProvider = FutureProvider.autoDispose.family<void, int>((
-  ref,
-  index,
-) async {
-  final config = ref.watch(_splashConfigProvider);
-  final tasks = config?.reactiveTasks;
-  if (config == null || tasks == null || index >= tasks.length) return;
+final _reactiveSplashTasksExecuteProvider = FutureProvider.autoDispose
+    .family<void, int>((
+      ref,
+      index,
+    ) async {
+      final config = ref.watch(_splashConfigProvider);
+      final tasks = config?.reactiveTasks;
+      if (config == null || tasks == null || index >= tasks.length) return;
 
-  final data = await ref.watch(_reactiveSplashTasksProvider(index).future);
-  await tasks[index].execute(ref, data);
-});
+      final data = await ref.watch(_reactiveSplashTasksProvider(index).future);
+      await tasks[index].execute(ref, data);
+    });
 
 @visibleForTesting
 Provider<SplashConfig?> get splashConfigProvider => _splashConfigProvider;
 
 @visibleForTesting
-FutureProvider<bool> get oneTimeSplashTasksProvider => _oneTimeSplashTasksProvider;
+FutureProvider<bool> get oneTimeSplashTasksProvider =>
+    _oneTimeSplashTasksProvider;
 
 @visibleForTesting
 FutureProvider<dynamic> Function(int) get reactiveSplashTasksProvider =>
@@ -91,7 +96,8 @@ class SplashTaskError implements Exception {
 
 class SplashConfig {
   /// The splash screen widget builder. For injecting splash widget
-  final Widget Function(SplashTaskError? error, VoidCallback? retry) splashBuilder;
+  final Widget Function(SplashTaskError? error, VoidCallback? retry)
+  splashBuilder;
 
   final List<Future<void> Function(Ref ref)> oneTimeTasks;
 

--- a/lib/src/splash_task.dart
+++ b/lib/src/splash_task.dart
@@ -75,20 +75,16 @@ class SplashTaskError implements Exception {
   @override
   String toString() {
     final buffer = StringBuffer('SplashTaskError');
-    // Only include error if not null, and avoid exposing sensitive info
-    if (error != null) {
-      buffer.write(': ');
-      // Only print the type and message, not the full object if possible
-      buffer.write(error.runtimeType);
-      if (error is Exception || error is Error) {
-        buffer.write(': ${error.toString()}');
-      }
+    // Only include error, and avoid exposing sensitive info
+    buffer.write(': ');
+    // Only print the type and message, not the full object if possible
+    buffer.write(error.runtimeType);
+    if (error is Exception || error is Error) {
+      buffer.write(': ${error.toString()}');
     }
-    // Only include stack trace if not null, and only the first few lines
-    if (stack != null) {
-      final stackStr = stack.toString().split('\n').take(5).join('\n');
-      buffer.write('\nStack trace (first 5 lines):\n$stackStr');
-    }
+    // Only include stack trace, and only the first few lines
+    final stackStr = stack.toString().split('\n').take(5).join('\n');
+    buffer.write('\nStack trace (first 5 lines):\n$stackStr');
     return buffer.toString();
   }
 }

--- a/lib/src/splash_task.dart
+++ b/lib/src/splash_task.dart
@@ -73,7 +73,24 @@ class SplashTaskError implements Exception {
   SplashTaskError({required this.error, required this.stack});
 
   @override
-  String toString() => 'SplashTaskError: $error\n$stack';
+  String toString() {
+    final buffer = StringBuffer('SplashTaskError');
+    // Only include error if not null, and avoid exposing sensitive info
+    if (error != null) {
+      buffer.write(': ');
+      // Only print the type and message, not the full object if possible
+      buffer.write(error.runtimeType);
+      if (error is Exception || error is Error) {
+        buffer.write(': ${error.toString()}');
+      }
+    }
+    // Only include stack trace if not null, and only the first few lines
+    if (stack != null) {
+      final stackStr = stack.toString().split('\n').take(5).join('\n');
+      buffer.write('\nStack trace (first 5 lines):\n$stackStr');
+    }
+    return buffer.toString();
+  }
 }
 
 class SplashConfig {

--- a/tool/bump_version.py
+++ b/tool/bump_version.py
@@ -117,7 +117,8 @@ def main() -> int:
     pubspec_path = "pubspec.yaml"
     changelog_path = "CHANGELOG.md"
 
-    content = open(pubspec_path, "r", encoding="utf-8").read()
+    with open(pubspec_path, "r", encoding="utf-8") as fh:
+        content = fh.read()
     match = re.search(r"^version:\s*([0-9]+\.[0-9]+\.[0-9]+)", content, re.MULTILINE)
     if not match:
         raise RuntimeError("Could not find version in pubspec.yaml")

--- a/tool/bump_version.py
+++ b/tool/bump_version.py
@@ -116,7 +116,8 @@ def _set_output(key: str, value: str) -> None:
 def main() -> int:
     pubspec_path = "pubspec.yaml"
     changelog_path = "CHANGELOG.md"
-
+    with open(pubspec_path, "r", encoding="utf-8") as fh:
+        content = fh.read()
     with open(pubspec_path, "r", encoding="utf-8") as fh:
         content = fh.read()
     match = re.search(r"^version:\s*([0-9]+\.[0-9]+\.[0-9]+)", content, re.MULTILINE)

--- a/tool/bump_version.py
+++ b/tool/bump_version.py
@@ -95,6 +95,7 @@ def _update_changelog(path: str, new_version: str, commits: list[Commit]) -> str
     if os.path.exists(path):
         with open(path, "r", encoding="utf-8") as fh:
             previous = fh.read().strip()
+            previous = fh.read().strip()
 
     combined = new_entry + ("\n\n" + previous if previous else "\n")
     with open(path, "w", encoding="utf-8") as fh:


### PR DESCRIPTION
This pull request refactors error handling for splash tasks by introducing a dedicated `SplashTaskError` class, replacing the previous tuple-based error representation. Additionally, it cleans up provider declarations for improved code consistency and readability.

**Error handling improvements:**

* Introduced the `SplashTaskError` class to encapsulate error and stack trace information, replacing the previous tuple pattern throughout the codebase. (`lib/src/splash_task.dart`, `lib/src/splash_builder.dart`) (Ff94ccb3L66R66, [lib/src/splash_builder.dartL164-R180](diffhunk://#diff-144ba130489a5664000deeed8dfd05e3ac03bcce12488f42053b38941441c6edL164-R180))
* Updated the `splashBuilder` callback signature in `SplashConfig` and related usages to accept a `SplashTaskError?` instead of a tuple. (`lib/src/splash_task.dart`, `lib/src/splash_builder.dart`) [[1]](diffhunk://#diff-0a87a299eb81768640be85de7ed111094b54b5740c2af44d17dcdc56548e46a5R69-R81) [[2]](diffhunk://#diff-144ba130489a5664000deeed8dfd05e3ac03bcce12488f42053b38941441c6edL164-R180)

**Provider and formatting cleanup:**

* Reformatted provider declarations for `_splashConfigProvider`, `_oneTimeSplashTasksProvider`, `_reactiveSplashTasksProvider`, and `_reactiveSplashTasksExecuteProvider` to single-line style for consistency and readability. (`lib/src/splash_task.dart`) [[1]](diffhunk://#diff-0a87a299eb81768640be85de7ed111094b54b5740c2af44d17dcdc56548e46a5L3-R3) [[2]](diffhunk://#diff-0a87a299eb81768640be85de7ed111094b54b5740c2af44d17dcdc56548e46a5L33-R31) [[3]](diffhunk://#diff-0a87a299eb81768640be85de7ed111094b54b5740c2af44d17dcdc56548e46a5L46-R43) [[4]](diffhunk://#diff-0a87a299eb81768640be85de7ed111094b54b5740c2af44d17dcdc56548e46a5L63-R59)
* Minor formatting improvements in conditional expressions and method calls for better clarity. (`lib/src/splash_builder.dart`, `lib/src/splash_task.dart`) [[1]](diffhunk://#diff-144ba130489a5664000deeed8dfd05e3ac03bcce12488f42053b38941441c6edL135-R135) [[2]](diffhunk://#diff-0a87a299eb81768640be85de7ed111094b54b5740c2af44d17dcdc56548e46a5L63-R59)