### PR TITLE
feat(splash): fix reactive task error handling to prevent unnecessary splash screen display

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverboot
 description: "App bootstrap & splash task system for Flutter with Riverpod"
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ^3.9.2


### PR DESCRIPTION
Convert SplashBuilder to StatefulWidget to track trigger-caused refreshes. Add _triggerCausedRefresh flag to distinguish between trigger changes (show splash) and other refreshes like errors or dependency changes (don't show splash). Update reactive task completion logic to skip splash when errors occur without trigger change. Set trigger flag on manual retry. Clear flag after reactive task completes using